### PR TITLE
BSON.BinData support, consistency & security fixes

### DIFF
--- a/mongo_gridfile.cpp
+++ b/mongo_gridfile.cpp
@@ -184,7 +184,7 @@ static int gridfile_write(lua_State *L) {
     const char *where = luaL_checkstring(L, 2);
 
     try {
-        gridfile->write(lua_tostring(L, 2));
+        gridfile->write(where);
     } catch (std::exception &e) {
         lua_pushboolean(L, 0);
         lua_pushfstring(L, LUAMONGO_ERR_CALLING, LUAMONGO_GRIDFILE, "write", e.what());


### PR DESCRIPTION
- Add support for BSON.BinData
- Add cyclic table reference checks in BSON building (infinite recursion)
- Consistency & security checks:
  - Avoid long jumps from luaL_error which caused memory leaks (structures on the stack are not destructed)
  - Check string pointers before use to avoid segfaults on bad input
  - Check Lua stack size to allow safe nested table traversing
- Minor makeup
