### PR TITLE
Two fixes for luamongo

### DIFF
--- a/mongo_connection.cpp
+++ b/mongo_connection.cpp
@@ -36,7 +36,7 @@ static int connection_new(lua_State *L) {
 
     try {
         bool auto_reconnect;
-        double rw_timeout;
+        double rw_timeout=0;
         if (lua_type(L,1) == LUA_TTABLE) {
             // extract arguments from table
             lua_getfield(L, 1, "auto_reconnect");


### PR DESCRIPTION
I was trying to use LuaMongo in my Nginx environment, and I realized that I wanted to change the timeout (to prevent Nginx from being blocked by a slow lookup), but the timeout didn't seem to change. A quick glance at the source code indicated that the timeout wasn't ever being set based on the docs. The docs were right that you were trying to coerce the timeout to an integer, despite the fact that MongoDB accepts a double. But even the int you were reading was never getting set, because of a shadowed stack variable.

The docs were wrong about the parameters being parameters too (they were actually table values), though I changed that on the Wiki. Ideally if this gets accepted into luamongo the docs will get updated to show that it takes a double now.

Other than that, luamongo is showing me some really fast write action from Nginx/LuaJit, which is great. Not sure if Matt is reading these comments, but thanks Matt for pointing me at this. 

Tim
