### PR TITLE
Fix BSON parsing to treat numbers larger than INT_MAX as doubles

### DIFF
--- a/utils.cpp
+++ b/utils.cpp
@@ -13,6 +13,7 @@ extern "C" {
 
 #include "utils.h"
 #include "common.h"
+#include <limits.h>
 
 using namespace mongo;
 
@@ -246,7 +247,7 @@ static void lua_append_bson(lua_State *L, const char *key, int stackpos, BSONObj
         builder->appendNull(key);
     } else if (type == LUA_TNUMBER) {
         double numval = lua_tonumber(L, stackpos);
-        if (numval == floor(numval)) {
+        if ((numval == floor(numval)) && fabs(numval)< INT_MAX ) {
             // The numeric value looks like an integer, treat it as such.
             // This is closer to how JSON datatypes behave.
             int intval = lua_tointeger(L, stackpos);


### PR DESCRIPTION
Hi,

I had a case where ended up pushing large numbers into MongoDB, and they ended up squeezed into an int32_t. This patch adds a simple "If < INT_MAX" at the point where it decides to use an int or a double.

Tim
