### PR TITLE
LuaJIT implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 CC= g++
-CFLAGS= -Wall -fno-strict-aliasing -g -O2 -shared -fPIC -I/usr/include/mongo `pkg-config --cflags luajit` `pkg-config --cflags libmongo-client`
+LUAPKG:= $(shell ( luajit -e 'print("luajit")'  2> /dev/null ) || lua5.2 -e 'print("lua52")'  2> /dev/null || lua5.1 -e 'print("lua51")'  2> /dev/null || lua -e 'print("lua" .. string.match(_VERSION, "%d.%d"))'  2> /dev/null | cut -d' ' -f 2)
+CFLAGS= -Wall -g -O2 -shared -fPIC -I/usr/include/mongo `pkg-config --cflags $(LUAPKG)` `pkg-config --cflags libmongo-client`
 AR= ar rcu
 RANLIB= ranlib
 RM= rm -f
-LIBS=`pkg-config --libs lua5.2` -lmongoclient -lssl -lboost_thread -lboost_filesystem
+LIBS=`pkg-config --libs $(LUAPKG)` -lmongoclient -lssl -lboost_thread -lboost_filesystem
 OUTLIB=mongo.so
 
 LDFLAGS= $(LIBS)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC= g++
-CFLAGS= -Wall -g -O2 -shared -fPIC -I/usr/include/mongo `pkg-config --cflags lua5.2` `pkg-config --cflags libmongo-client`
+CFLAGS= -Wall -fno-strict-aliasing -g -O2 -shared -fPIC -I/usr/include/mongo `pkg-config --cflags luajit` `pkg-config --cflags libmongo-client`
 AR= ar rcu
 RANLIB= ranlib
 RM= rm -f

--- a/Makefile.darwin
+++ b/Makefile.darwin
@@ -14,11 +14,12 @@ endif
 .PHONY:	checklib
 
 CC= g++
-CFLAGS= -Wall -fno-strict-aliasing -g -O2 -fPIC `pkg-config --cflags "luajit >= 2.0.3"` -I$(MONGO_INCLUDE_DIR)
+LUAPKG:= $(shell ( luajit -e 'print("luajit")'  2> /dev/null ) || lua5.2 -e 'print("lua52")'  2> /dev/null || lua5.1 -e 'print("lua51")'  2> /dev/null || lua -e 'print("lua" .. string.match(_VERSION, "%d.%d"))'  2> /dev/null | cut -d' ' -f 2)
+CFLAGS= -Wall -g -O2 -fPIC `pkg-config --cflags $(LUAPKG)` -I$(MONGO_INCLUDE_DIR)
 AR= ar rcu
 RANLIB= ranlib
 RM= rm -f
-LIBS=`pkg-config --libs "luajit >= 2.0.3"` -lmongoclient -lssl -lboost_thread-mt -lboost_filesystem-mt -flat_namespace -bundle -L$(MONGO_LIB_DIR) -rdynamic
+LIBS=`pkg-config --libs $(LUAPKG)` -lmongoclient -lssl -lboost_thread-mt -lboost_filesystem-mt -flat_namespace -bundle -L$(MONGO_LIB_DIR) -rdynamic
 OUTLIB=mongo.so
 
 LDFLAGS= $(LIBS)

--- a/Makefile.darwin
+++ b/Makefile.darwin
@@ -14,11 +14,11 @@ endif
 .PHONY:	checklib
 
 CC= g++
-CFLAGS= -Wall -g -O2 -fPIC `pkg-config --cflags "lua >= 5.2"` -I$(MONGO_INCLUDE_DIR)
+CFLAGS= -Wall -fno-strict-aliasing -g -O2 -fPIC `pkg-config --cflags "luajit >= 2.0.3"` -I$(MONGO_INCLUDE_DIR)
 AR= ar rcu
 RANLIB= ranlib
 RM= rm -f
-LIBS=`pkg-config --libs "lua >= 5.2"` -lmongoclient -lssl -lboost_thread-mt -lboost_filesystem-mt -flat_namespace -bundle -L$(MONGO_LIB_DIR) -rdynamic
+LIBS=`pkg-config --libs "luajit >= 2.0.3"` -lmongoclient -lssl -lboost_thread-mt -lboost_filesystem-mt -flat_namespace -bundle -L$(MONGO_LIB_DIR) -rdynamic
 OUTLIB=mongo.so
 
 LDFLAGS= $(LIBS)

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -1,9 +1,10 @@
 CC= g++
-CFLAGS= -Wall -fno-strict-aliasing -g -O2 -shared -fPIC -I/usr/include/mongo `pkg-config --cflags luajit` `pkg-config --cflags libmongo-client`
+LUAPKG:= $(shell ( luajit -e 'print("luajit")'  2> /dev/null ) || lua5.2 -e 'print("lua52")'  2> /dev/null || lua5.1 -e 'print("lua51")'  2> /dev/null || lua -e 'print("lua" .. string.match(_VERSION, "%d.%d"))'  2> /dev/null | cut -d' ' -f 2)
+CFLAGS= -Wall -g -O2 -shared -fPIC -I/usr/include/mongo `pkg-config --cflags $(LUAPKG)` `pkg-config --cflags libmongo-client`
 AR= ar rcu
 RANLIB= ranlib
 RM= rm -f
-LIBS=`pkg-config --libs luajit` -lmongoclient -lssl -lboost_thread -lboost_filesystem -lrt
+LIBS=`pkg-config --libs $(LUAPKG)` -lmongoclient -lssl -lboost_thread -lboost_filesystem -lrt
 OUTLIB=mongo.so
 
 LDFLAGS= $(LIBS)

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -1,9 +1,9 @@
 CC= g++
-CFLAGS= -Wall -g -O2 -shared -fPIC -I/usr/include/mongo `pkg-config --cflags lua5.2` `pkg-config --cflags libmongo-client`
+CFLAGS= -Wall -fno-strict-aliasing -g -O2 -shared -fPIC -I/usr/include/mongo `pkg-config --cflags luajit` `pkg-config --cflags libmongo-client`
 AR= ar rcu
 RANLIB= ranlib
 RM= rm -f
-LIBS=`pkg-config --libs lua5.2` -lmongoclient -lssl -lboost_thread -lboost_filesystem -lrt
+LIBS=`pkg-config --libs luajit` -lmongoclient -lssl -lboost_thread -lboost_filesystem -lrt
 OUTLIB=mongo.so
 
 LDFLAGS= $(LIBS)

--- a/mongo_bsontypes.cpp
+++ b/mongo_bsontypes.cpp
@@ -375,8 +375,11 @@ int mongo_bsontypes_register(lua_State *L) {
         {NULL, NULL}
     };
 
-    //luaL_register(L, LUAMONGO_ROOT, bsontype_methods);    
+    #if LUA_VERSION_NUM < 502
+    luaL_register(L, LUAMONGO_ROOT, bsontype_methods); 
+    #else
     luaL_newlib(L, bsontype_methods);
+    #endif
     
     return 1;
 }

--- a/mongo_connection.cpp
+++ b/mongo_connection.cpp
@@ -120,8 +120,11 @@ int mongo_connection_register(lua_State *L) {
     
     lua_pop(L,1);
     
-    //luaL_register(L, LUAMONGO_CONNECTION, connection_class_methods);
+    #if LUA_VERSION_NUM < 502
+    luaL_register(L, LUAMONGO_CONNECTION, connection_class_methods);
+    #else
     luaL_newlib(L, connection_class_methods);
+    #endif
 
     return 1;
 }

--- a/mongo_cursor.cpp
+++ b/mongo_cursor.cpp
@@ -194,8 +194,11 @@ int mongo_cursor_register(lua_State *L) {
     
     lua_pop(L,1);
     
-    //luaL_register(L, LUAMONGO_CURSOR, cursor_class_methods);
+    #if LUA_VERSION_NUM < 502
+    luaL_register(L, LUAMONGO_CURSOR, cursor_class_methods);
+    #else
     luaL_newlib(L, cursor_class_methods);
-
+    #endif
+    
     return 1;
 }

--- a/mongo_cxx_extension.cpp
+++ b/mongo_cxx_extension.cpp
@@ -20,6 +20,8 @@
  * IN THE SOFTWARE.
  */
 
+#include <iostream>
+#include <stdlib.h>
 #include <client/redef_macros.h>
 #include <client/dbclient.h>
 #include <client/gridfs.h>

--- a/mongo_gridfile.cpp
+++ b/mongo_gridfile.cpp
@@ -265,8 +265,11 @@ int mongo_gridfile_register(lua_State *L) {
 
     lua_pop(L,1);
 
-    //luaL_register(L, LUAMONGO_GRIDFILE, gridfile_class_methods);
+    #if LUA_VERSION_NUM < 502
+    luaL_register(L, LUAMONGO_GRIDFILE, gridfile_class_methods);
+    #else
     luaL_newlib(L, gridfile_class_methods);
+    #endif
 
     return 1;
 }

--- a/mongo_gridfilebuilder.cpp
+++ b/mongo_gridfilebuilder.cpp
@@ -163,7 +163,11 @@ int mongo_gridfilebuilder_register(lua_State *L) {
     
   lua_pop(L,1);
 
+  #if LUA_VERSION_NUM < 502
+  luaL_register(L, LUAMONGO_GRIDFILEBUILDER, gridfilebuilder_class_methods);
+  #else
   luaL_newlib(L, gridfilebuilder_class_methods);
+  #endif
 
   return 1;
 }

--- a/mongo_gridfs.cpp
+++ b/mongo_gridfs.cpp
@@ -246,8 +246,11 @@ int mongo_gridfs_register(lua_State *L) {
     
     lua_pop(L,1);
 
-    //luaL_register(L, LUAMONGO_GRIDFS, gridfs_class_methods);
+    #if LUA_VERSION_NUM < 502
+    luaL_register(L, LUAMONGO_GRIDFS, gridfs_class_methods);
+    #else
     luaL_newlib(L, gridfs_class_methods);
+    #endif
 
     return 1;
 }

--- a/mongo_gridfschunk.cpp
+++ b/mongo_gridfschunk.cpp
@@ -96,8 +96,11 @@ int mongo_gridfschunk_register(lua_State *L) {
 
     lua_pop(L,1);
 
-    //luaL_register(L, LUAMONGO_GRIDFSCHUNK, gridfschunk_class_methods);
+    #if LUA_VERSION_NUM < 502
+    luaL_register(L, LUAMONGO_GRIDFSCHUNK, gridfschunk_class_methods);
+    #else
     luaL_newlib(L, gridfschunk_class_methods);
+    #endif
 
     return 1;
 }

--- a/mongo_query.cpp
+++ b/mongo_query.cpp
@@ -346,8 +346,11 @@ int mongo_query_register(lua_State *L) {
     
     lua_pop(L,1);
     
-    //luaL_register(L, LUAMONGO_QUERY, query_class_methods);
+    #if LUA_VERSION_NUM < 502
+    luaL_register(L, LUAMONGO_QUERY, query_class_methods);
+    #else
     luaL_newlib(L, query_class_methods);
+    #endif
 
     lua_pushstring(L, "Options");
     lua_newtable(L);

--- a/mongo_replicaset.cpp
+++ b/mongo_replicaset.cpp
@@ -119,8 +119,11 @@ int mongo_replicaset_register(lua_State *L) {
     
     lua_pop(L,1);
     
-    //luaL_register(L, LUAMONGO_REPLICASET, replicaset_class_methods);
+    #if LUA_VERSION_NUM < 502
+    luaL_register(L, LUAMONGO_REPLICASET, replicaset_class_methods);
+    #else
     luaL_newlib(L, replicaset_class_methods);
+    #endif
 
     return 1;
 }

--- a/utils.cpp
+++ b/utils.cpp
@@ -363,3 +363,18 @@ LUALIB_API int luaL_typeerror (lua_State *L, int narg, const char *tname) {
                         tname, lua_typename(L, narg));
   return luaL_argerror(L, narg, msg);
 }
+
+#if LUA_VERSION_NUM < 502
+LUALIB_API void luaL_setfuncs(lua_State *L, const luaL_Reg *l, int nup) {
+  luaL_checkstack(L, nup+1, "too many upvalues");
+  for (; l->name != NULL; l++) {  /* fill the table with given functions */
+    int i;
+    lua_pushstring(L, l->name);
+    for (i = 0; i < nup; i++)  /* copy upvalues to the top */
+      lua_pushvalue(L, -(nup+1));
+    lua_pushcclosure(L, l->func, nup);  /* closure with those upvalues */
+    lua_settable(L, -(nup + 3));
+  }
+  lua_pop(L, nup);  /* remove upvalues */
+}
+#endif

--- a/utils.h
+++ b/utils.h
@@ -35,7 +35,11 @@ extern "C" {
 #include <lauxlib.h>
 #include <lualib.h>
 
-#if defined(LUA_VERSION_NUM) && (LUA_VERSION_NUM < 502)
+#if !defined(LUA_VERSION_NUM) || (LUA_VERSION_NUM < 501)
+#error "Needs Lua 5.1 or greater"
+#endif
+
+#if LUA_VERSION_NUM < 502
 #define lua_rawlen lua_objlen
 #endif
 };

--- a/utils.h
+++ b/utils.h
@@ -49,7 +49,7 @@ extern "C" {
 /* this was removed in Lua 5.2 */
 LUALIB_API int luaL_typeerror (lua_State *L, int narg, const char *tname);
 
-#if defined(LUA_VERSION_NUM) && (LUA_VERSION_NUM < 502)
+#if LUA_VERSION_NUM < 502
 LUALIB_API void luaL_setfuncs(lua_State *L, const luaL_Reg *l, int nup);
 #endif
 

--- a/utils.h
+++ b/utils.h
@@ -35,8 +35,8 @@ extern "C" {
 #include <lauxlib.h>
 #include <lualib.h>
 
-#if !defined(LUA_VERSION_NUM) || (LUA_VERSION_NUM < 502)
-#error "Needs Lua 5.2 or greater"
+#if defined(LUA_VERSION_NUM) && (LUA_VERSION_NUM < 502)
+#define lua_rawlen lua_objlen
 #endif
 };
 
@@ -44,6 +44,10 @@ extern "C" {
 
 /* this was removed in Lua 5.2 */
 LUALIB_API int luaL_typeerror (lua_State *L, int narg, const char *tname);
+
+#if defined(LUA_VERSION_NUM) && (LUA_VERSION_NUM < 502)
+LUALIB_API void luaL_setfuncs(lua_State *L, const luaL_Reg *l, int nup);
+#endif
 
 #define LUA_PUSH_ATTRIB_INT(n, v) \
     lua_pushstring(L, n); \


### PR DESCRIPTION
There is an additional change of "-fno-strict-aliasing" which is simply required for a certain version of gcc due to error: "dereferencing type-punned pointer will break strict-aliasing rules"

Also, we are still missing the ability to chose between LuaJIT / Lua5.1 and Lua5.2 (some changes in Makefile are required).