### PR TITLE
update LICENSE copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,8 @@ The MIT License (MIT)
 
 Copyright (c) 2014-2015 Francisco Zamora-Martinez (pakozm@gmail.com)
 Copyright (c) 2009-2015 Zipline Games, Inc.
+Copyright (c) 2010-2012 Evan Wies (evan@neomantra.com)
+Copyright (c) 2009-2010 Neil Richardson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Extracted from copyrights in debian/copyright

I just noted that there is now a LICENSE file for this project, in addition to the original debian/copyright.  I copied myself and Neil from there to the LICENSE file.

Thank you for moving this project to GitHub and keeping the library alive.